### PR TITLE
Parse log levels from cw entries

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ module "cloudwatch-log-group-x-papertrail" {
     monitor_log_group_arn = ARN_OF_THE_LOG_GROUP
     papertrail_host = "logsX.papertrailapp.com"
     papertrail_port = "12345"
-    filter_pattern = FILTER_PATTERN or empty string
+    filter_pattern = FILTER_PATTERN | ""
     timeout = "10"
     lambda_log_role_arn = ARN_OF_LAMDA_ROLE_WITH_CW_LOGS_WRITE_PERMISSION
     lambda_name_prefix = "MyLambdaFunction"
+    parse_log_levels = "true"
 }
 ```
 
@@ -49,6 +50,7 @@ Note: Some of the variables have default values and don't need to be explicitly 
 3. Using Terraform modules directly from Github reporitories does not support proper versioning, but you can use the `ref` query parameter to refer to a specific tag in the repository, please check the CHANGELOG.md file for which versions are available and what has been updated in each version
 4. Check your Papertrail "Destination settings" for the correct values for `papertrail_host` and `papertrail_port`
 5. You may have noticed that we have checked in some Javascript files that are built from typescript files as well as node_modules dependencies into version control. There are two reasons for this: 1) We rely on Github for hosting the files, for simplicity, and 2) We want to reduce the number of system dependencies for the user, this way the user doesn't even need node/npm
+6. If you enable the `parse_log_levels` functionality to parse out the log level from the cloudwatch log messages, you must use the npm winston simple log format that prefixes log entries with "LOGLEVEL:"
 
 # Acknowledgements
 

--- a/cloudwatch-papertrail.ts
+++ b/cloudwatch-papertrail.ts
@@ -46,7 +46,8 @@ function getEnvVarOrFail(varName: string): string {
   return value
 }
 
-// Should match for example: "[error] The database has exploded"
+// Should match winston simple log format for example: "error: The database has exploded"
+// For more information see https://github.com/winstonjs/winston
 // The pattern represents the following:
 // A sequence of non-tab chars at the start of input followed by a tab
 // Another sequence of non-tabs followed by a tab

--- a/cloudwatch-papertrail.ts
+++ b/cloudwatch-papertrail.ts
@@ -50,11 +50,10 @@ function getEnvVarOrFail(varName: string): string {
 const logLevelRegex = /^\[(\w+)\]/
 
 export function parseLogLevel(tsvMessage: string): string | undefined {
-  // The message is a tab separated value string of three columns:
+  // Messages logged manually are tab separated value strings of three columns:
   // date string (ISO8601), request ID, log message
   const messageColumns = tsvMessage.split("\t")
   if (messageColumns.length != 3) {
-    console.warn('Got message with unexpected number of TSV columns:', tsvMessage)
     return undefined
   }
   const message = messageColumns[2]

--- a/cloudwatch-papertrail.ts
+++ b/cloudwatch-papertrail.ts
@@ -47,22 +47,17 @@ function getEnvVarOrFail(varName: string): string {
 }
 
 // Should match for example: "[error] The database has exploded"
-const logLevelRegex = /^\[(\w+)\]/
+// The pattern represents the following:
+// A sequence of non-tab chars at the start of input followed by a tab
+// Another sequence of non-tabs followed by a tab
+// Capture a group of alphanumeric chars enclosed in [ and ]
+const logLevelRegex = /^[^\t]+\t[^\t]+\t\[(\w+)\]/
 
-export function parseLogLevel(tsvMessage: string): string | undefined {
+export function parseLogLevel(tsvMessage: string): string | null {
   // Messages logged manually are tab separated value strings of three columns:
   // date string (ISO8601), request ID, log message
-  const messageColumns = tsvMessage.split("\t")
-  if (messageColumns.length != 3) {
-    return undefined
-  }
-  const message = messageColumns[2]
-  const match = logLevelRegex.exec(message)
-  if (match) {
-    return match[1].toLowerCase()
-  } else {
-    return undefined
-  }
+  const match = logLevelRegex.exec(tsvMessage)
+  return match && match[1].toLowerCase()
 }
 
 export const handler: AwsLambda.Handler = (event: CloudwatchLogGroupsEvent, context, callback) => {

--- a/cloudwatch-papertrail.ts
+++ b/cloudwatch-papertrail.ts
@@ -50,8 +50,8 @@ function getEnvVarOrFail(varName: string): string {
 // The pattern represents the following:
 // A sequence of non-tab chars at the start of input followed by a tab
 // Another sequence of non-tabs followed by a tab
-// Capture a group of alphanumeric chars enclosed in [ and ]
-const logLevelRegex = /^[^\t]+\t[^\t]+\t\[(\w+)\]/
+// Capture a group of alphanumeric chars leading up to a ':'
+const logLevelRegex = /^[^\t]+\t[^\t]+\t(\w+):/
 
 export function parseLogLevel(tsvMessage: string): string | null {
   // Messages logged manually are tab separated value strings of three columns:

--- a/cloudwatch-papertrail.ts
+++ b/cloudwatch-papertrail.ts
@@ -49,7 +49,15 @@ function getEnvVarOrFail(varName: string): string {
 // Should match for example: "[error] The database has exploded"
 const logLevelRegex = /^\[(\w+)\]/
 
-export function parseLogLevel(message: string): string | undefined {
+export function parseLogLevel(tsvMessage: string): string | undefined {
+  // The message is a tab separated value string of three columns:
+  // date string (ISO8601), request ID, log message
+  const messageColumns = tsvMessage.split("\t")
+  if (messageColumns.length != 3) {
+    console.warn('Got message with unexpected number of TSV columns:', tsvMessage)
+    return undefined
+  }
+  const message = messageColumns[2]
   const match = logLevelRegex.exec(message)
   if (match) {
     return match[1].toLowerCase()

--- a/cloudwatch-papertrail.ts
+++ b/cloudwatch-papertrail.ts
@@ -46,10 +46,23 @@ function getEnvVarOrFail(varName: string): string {
   return value
 }
 
+// Should match for example: "[error] The database has exploded"
+const logLevelRegex = /^\[(\w+)\]/
+
+export function parseLogLevel(message: string): string | undefined {
+  const match = logLevelRegex.exec(message)
+  if (match) {
+    return match[1].toLowerCase()
+  } else {
+    return undefined
+  }
+}
+
 export const handler: AwsLambda.Handler = (event: CloudwatchLogGroupsEvent, context, callback) => {
   const payload = new Buffer(event.awslogs.data, 'base64');
   const host = getEnvVarOrFail('PAPERTRAIL_HOST')
   const port = getEnvVarOrFail('PAPERTRAIL_PORT')
+  const shouldParseLogLevels = getEnvVarOrFail('PARSE_LOG_LEVELS') === "true"
 
   unarchiveLogData(payload)
     .then((logData: LogData) => {
@@ -68,8 +81,11 @@ export const handler: AwsLambda.Handler = (event: CloudwatchLogGroupsEvent, cont
         transports: [papertrailTransport]
       });
 
-      logData.logEvents.forEach(function (line) {
-        logger.info(line.message);
+      logData.logEvents.forEach(function (event) {
+        const logLevel = shouldParseLogLevels
+          ? parseLogLevel(event.message) || 'info'
+          : 'info'
+        logger.log(logLevel, event.message);
       });
 
       logger.close()

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,28 @@
       "integrity": "sha512-vmdlXJqGAM4OQDMA3GoqC0jqokHLVy11YQsrFRScRffpuxQ4NX+ni1IBidwIb+fxCgM6aoTClDgNhlNfsygP7w==",
       "dev": true
     },
+    "@types/mocha": {
+      "version": "2.2.44",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.44.tgz",
+      "integrity": "sha512-k2tWTQU8G4+iSMvqKi0Q9IIsWAp/n8xzdZS4Q4YVIltApoMA00wFBFdlJnmoaK1/z7B0Cy0yPe6GgXteSmdUNw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.1.tgz",
       "integrity": "sha512-SrmAO+NhnsuG/6TychSl2VdxBZiw/d6V+8j+DFo8O3PwFi+QeYXWHhAw+b170aSc6zYab6/PjEWRZHIDN9mNUw==",
+      "dev": true
+    },
+    "@types/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
+      "dev": true
+    },
+    "@types/strip-json-comments": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
     },
     "@types/winston": {
@@ -44,6 +62,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "async": {
@@ -90,6 +114,12 @@
         "concat-map": "0.0.1"
       }
     },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -101,6 +131,15 @@
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
+    },
+    "ceylon": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/ceylon/-/ceylon-0.9.1.tgz",
+      "integrity": "sha1-e5944+a4F+Q3ftoGPC/ZZztYBkQ=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1"
+      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -146,6 +185,21 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -211,10 +265,31 @@
         "es5-ext": "0.10.37"
       }
     },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
     "deep-extend": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
     },
     "dot-prop": {
@@ -445,6 +520,12 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -452,6 +533,27 @@
       "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "1.0.0"
       }
     },
     "imurmurhash": {
@@ -583,6 +685,12 @@
         "es5-ext": "0.10.37"
       }
     },
+    "make-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
+      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
+      "dev": true
+    },
     "memoizee": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.10.tgz",
@@ -622,6 +730,41 @@
         "minimist": "0.0.8"
       }
     },
+    "mocha": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "modclean": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/modclean/-/modclean-2.1.2.tgz",
@@ -645,6 +788,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/modclean-patterns-default/-/modclean-patterns-default-1.1.1.tgz",
       "integrity": "sha1-UvCFIbosOVPt9XEdKEeYipRuHGQ=",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "next-tick": {
@@ -722,6 +871,12 @@
       "requires": {
         "error-ex": "1.3.1"
       }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -865,6 +1020,21 @@
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+      "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.6.1"
+      }
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -898,6 +1068,12 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -942,6 +1118,73 @@
           "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
           "dev": true
         }
+      }
+    },
+    "ts-node": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.0.2.tgz",
+      "integrity": "sha512-mg7l6ON8asjnfzkTi1LFWKaOGHl5Jf1+5ij0MQ502YfC6+4FBgh/idJgw9aN9kei1Rf4/pmFpNuFE1YbcQdOTA==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "chalk": "2.3.0",
+        "diff": "3.3.1",
+        "make-error": "1.3.0",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.5.0",
+        "tsconfig": "7.0.0",
+        "v8flags": "3.0.1",
+        "yn": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "tsconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
+      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
+      "dev": true,
+      "requires": {
+        "@types/strip-bom": "3.0.0",
+        "@types/strip-json-comments": "0.0.30",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1"
       }
     },
     "typescript": {
@@ -992,6 +1235,15 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
       "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
       "dev": true
+    },
+    "v8flags": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.1.tgz",
+      "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "1.0.1"
+      }
     },
     "widest-line": {
       "version": "1.0.0",
@@ -1048,6 +1300,12 @@
       "requires": {
         "os-homedir": "1.0.2"
       }
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,15 +5,20 @@
   "main": "cloudwatch-papertrail.ts",
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf lambda-files"
+    "clean": "rm -rf lambda-files",
+    "test": "mocha --require ts-node/register --watch-extensions ts,tsx \"test/**/*.{ts,tsx}\""
   },
   "author": "Vaana",
   "license": "MIT",
   "devDependencies": {
     "@types/aws-lambda": "0.0.23",
+    "@types/mocha": "2.2.44",
     "@types/node": "8.5.1",
     "@types/winston": "2.3.7",
+    "ceylon": "0.9.1",
+    "mocha": "4.0.1",
     "modclean": "2.1.2",
+    "ts-node": "4.0.2",
     "typescript": "2.6.2"
   },
   "dependencies": {

--- a/prepare-module.sh
+++ b/prepare-module.sh
@@ -6,14 +6,18 @@
 # through the Terraform module
 
 mkdir -p lambda-files
+echo "* Compiling TypeScript sources"
 npm run-script build
 cp package.json lambda-files
 cd lambda-files || exit "Directory 'lambda-files' does not exist"
+echo "* Installing Javascript dependencies for Lambda"
 npm install --no-package-lock --production
+echo "* Removing test folder and package.json from Lambda source files"
+rm -rf test
 rm package.json
 cd ..
-# Remove unnecessary files from node_modules before checking in to version control
+echo "* Cleaning out unnecessary files from Lambda's node_modules"
 ./node_modules/.bin/modclean --no-progress --run --path lambda-files
-# Overwrite the lambda-files folder in tf_module
+echo "* Overwriting the lambda-files folder in tf_module"
 rm -rf tf_module/lambda-files
 mv lambda-files tf_module

--- a/prepare-module.sh
+++ b/prepare-module.sh
@@ -12,13 +12,13 @@ set -o pipefail
 mkdir -p lambda-files
 echo "* Compiling TypeScript sources"
 npm run-script build
-cp package.json lambda-files
+cp package.json package-lock.json lambda-files
 cd lambda-files || exit "Directory 'lambda-files' does not exist"
 echo "* Installing Javascript dependencies for Lambda"
 npm install --no-package-lock --production
 echo "* Removing test folder and package.json from Lambda source files"
 rm -rf test
-rm package.json
+rm package.json package-lock.json
 cd ..
 echo "* Cleaning out unnecessary files from Lambda's node_modules"
 ./node_modules/.bin/modclean --no-progress --run --path lambda-files

--- a/test/cloudwatch-papertrail-test.ts
+++ b/test/cloudwatch-papertrail-test.ts
@@ -5,10 +5,11 @@ import { parseLogLevel } from '../cloudwatch-papertrail';
 describe('cloudwatch-papertrail', () => {
   describe('parseLogLevel', () => {
     it('should return the log level lowercased if the message starts with a marker', () => {
-      expect(parseLogLevel('[ERROR] The database has exploded')).toEqual('error')
+      const logMessage = "2017-12-21T06:01:06.518Z\t553795a9-e614-11e7-b8be-319f71bb2584\t[ERROR] The database has exploded"
+      expect(parseLogLevel(logMessage)).toEqual('error')
     })
 
-    it('should return undefined if there is no log level marker', () => {
+    it("2017-12-21T06:01:06.518Z\t553795a9-e614-11e7-b8be-319f71bb2584\tshould return undefined if there is no log level marker", () => {
       expect(parseLogLevel('Successfully handled request')).toNotExist()
     })
   })

--- a/test/cloudwatch-papertrail-test.ts
+++ b/test/cloudwatch-papertrail-test.ts
@@ -1,0 +1,15 @@
+import expect from 'ceylon'
+import * as cloudwatchPapertrail from '../cloudwatch-papertrail'
+import { parseLogLevel } from '../cloudwatch-papertrail';
+
+describe('cloudwatch-papertrail', () => {
+  describe('parseLogLevel', () => {
+    it('should return the log level lowercased if the message starts with a marker', () => {
+      expect(parseLogLevel('[ERROR] The database has exploded')).toEqual('error')
+    })
+
+    it('should return undefined if there is no log level marker', () => {
+      expect(parseLogLevel('Successfully handled request')).toNotExist()
+    })
+  })
+})

--- a/test/cloudwatch-papertrail-test.ts
+++ b/test/cloudwatch-papertrail-test.ts
@@ -5,7 +5,7 @@ import { parseLogLevel } from '../cloudwatch-papertrail';
 describe('cloudwatch-papertrail', () => {
   describe('parseLogLevel', () => {
     it('should return the log level lowercased if the message starts with a marker', () => {
-      const logMessage = "2017-12-21T06:01:06.518Z\t553795a9-e614-11e7-b8be-319f71bb2584\t[ERROR] The database has exploded"
+      const logMessage = "2017-12-21T06:01:06.518Z\t553795a9-e614-11e7-b8be-319f71bb2584\terror: The database has exploded"
       expect(parseLogLevel(logMessage)).toEqual('error')
     })
 

--- a/test/cloudwatch-papertrail-test.ts
+++ b/test/cloudwatch-papertrail-test.ts
@@ -9,8 +9,8 @@ describe('cloudwatch-papertrail', () => {
       expect(parseLogLevel(logMessage)).toEqual('error')
     })
 
-    it("2017-12-21T06:01:06.518Z\t553795a9-e614-11e7-b8be-319f71bb2584\tshould return undefined if there is no log level marker", () => {
-      expect(parseLogLevel('Successfully handled request')).toNotExist()
+    it("2017-12-21T06:01:06.518Z\t553795a9-e614-11e7-b8be-319f71bb2584\tshould return null if there is no log level marker", () => {
+      expect(parseLogLevel('Successfully handled request')).toEqual(null)
     })
   })
 })

--- a/tf_module/lambda-files/cloudwatch-papertrail.js
+++ b/tf_module/lambda-files/cloudwatch-papertrail.js
@@ -26,7 +26,15 @@ function getEnvVarOrFail(varName) {
 }
 // Should match for example: "[error] The database has exploded"
 const logLevelRegex = /^\[(\w+)\]/;
-function parseLogLevel(message) {
+function parseLogLevel(tsvMessage) {
+    // The message is a tab separated value string of three columns:
+    // date string (ISO8601), request ID, log message
+    const messageColumns = tsvMessage.split("\t");
+    if (messageColumns.length != 3) {
+        console.warn('Got message with unexpected number of TSV columns:', tsvMessage);
+        return undefined;
+    }
+    const message = messageColumns[2];
     const match = logLevelRegex.exec(message);
     if (match) {
         return match[1].toLowerCase();

--- a/tf_module/lambda-files/cloudwatch-papertrail.js
+++ b/tf_module/lambda-files/cloudwatch-papertrail.js
@@ -27,11 +27,10 @@ function getEnvVarOrFail(varName) {
 // Should match for example: "[error] The database has exploded"
 const logLevelRegex = /^\[(\w+)\]/;
 function parseLogLevel(tsvMessage) {
-    // The message is a tab separated value string of three columns:
+    // Messages logged manually are tab separated value strings of three columns:
     // date string (ISO8601), request ID, log message
     const messageColumns = tsvMessage.split("\t");
     if (messageColumns.length != 3) {
-        console.warn('Got message with unexpected number of TSV columns:', tsvMessage);
         return undefined;
     }
     const message = messageColumns[2];

--- a/tf_module/main.tf
+++ b/tf_module/main.tf
@@ -30,6 +30,7 @@ resource "aws_lambda_function" "papertrail" {
         variables = {
             PAPERTRAIL_HOST = "${var.papertrail_host}"
             PAPERTRAIL_PORT = "${var.papertrail_port}"
+            PARSE_LOG_LEVELS = "${var.parse_log_levels}"
         }
     }
     source_code_hash = "${data.archive_file.papertrail_lambda.output_base64sha256}"

--- a/tf_module/variables.tf
+++ b/tf_module/variables.tf
@@ -30,3 +30,8 @@ variable "lambda_log_role_arn" {
 variable "lambda_name_prefix" {
     description = "Will be used to create the Papertrail sending Lambda function name as 'PREFIX-papertrail-lambda', has the same restrictions as a normal Lambda name"
 }
+
+variable "parse_log_levels" {
+    description = "If true, the log entries will be parsed for markers describing their log level"
+    default = "false"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
     /* Experimental Options */
   },
   "include": [
-    "cloudwatch-papertrail.ts"
+    "cloudwatch-papertrail.ts", "test/*.ts"
   ]
 }


### PR DESCRIPTION
Adds a new option parse_log_levels to the Terraform module. When this value is set to "true" the log entries will be parsed to see if the original log message string was prefixed with a marker "[LOG_LEVEL]", the LOG_LEVEL will be parsed out and used as the log level when sending entries to Papertrail.